### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vanilla ES + R • [TodoMVC](http://todomvc.com)
 
-> A port of the [Vanilla JS Example](http://todomvc.com/examples/vanillajs/), but translated into ES using R framework, a very simple and small "fremawork" for building user interfaces.
+> A port of the [Vanilla JS Example](http://todomvc.com/examples/vanillajs/), but translated into ES using R framework, a very simple and small "framework" for building user interfaces.
 
 ## Learning ES6
 


### PR DESCRIPTION
Typo: "fremawork" should be "framework"

I assume this wasn't a deliberate typo, since Brutal.js is referred to as a "framework" in the main repo on https://github.com/dosyago-coder-0/brutal.js