### PR TITLE
Fix FireFox bug

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -209,7 +209,7 @@
     if ( keyEvent.key !== 'Enter' ) {
       return;
     }
-    const {srcElement:source} = keyEvent;
+    const {target:source} = keyEvent;
     const text = source.value.trim();
     if ( ! text ) {
       return; 


### PR DESCRIPTION
Closes #2 . `srcElement` does not exist on the keyEvent object on FireFox.